### PR TITLE
Use XDG config dir

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -137,6 +137,8 @@ func OpenReposAndFilter(u Repolist) (Repolist, ReposWithErrors) {
 	return fr, er
 }
 
+// Obtains the XDG config dir from ENV variables
+// otherwise returns the current directory
 func configDir() string {
 	configdir, err := os.UserConfigDir()
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,8 +17,7 @@ import (
 )
 
 var (
-	home       = homeDir()
-	configPath = path.Join(home, ".unstaged.yaml")
+	configPath = path.Join(configDir(), ".unstaged.yaml")
 )
 
 // Repo is an indirect reference to a string.
@@ -138,10 +137,10 @@ func OpenReposAndFilter(u Repolist) (Repolist, ReposWithErrors) {
 	return fr, er
 }
 
-func homeDir() string {
-	homedir, err := os.UserHomeDir()
+func configDir() string {
+	configdir, err := os.UserConfigDir()
 	if err != nil {
 		return "./"
 	}
-	return homedir
+	return path.Join(configdir, "unstaged")
 }


### PR DESCRIPTION
Uses `XDG_CONFIG_HOME` from ENV variables in POSIX systems otherwise uses:
- $HOME/.config 
- $HOME/Library/Application (MacOSX)
- %AppData%. (Windows)
- $home/lib (Plan 9)
- /. (When HOME is undefined)

Fixes: #5 